### PR TITLE
Improving the monitoring button

### DIFF
--- a/UI/volume-control.cpp
+++ b/UI/volume-control.cpp
@@ -198,6 +198,8 @@ VolControl::VolControl(OBSSource source_, bool showConfig)
 #if defined(_WIN32) || defined(__APPLE__) || HAVE_PULSEAUDIO
 	headphone->setAccessibleName(
 			QTStr("VolControl.Headphones").arg(sourceName));
+	headphone->setToolTip(
+			QTStr("VolControl.Headphones").arg(sourceName));
 
 	switch (obs_source_get_monitoring_type(source)) {
 		case OBS_MONITORING_TYPE_NONE:

--- a/UI/volume-control.cpp
+++ b/UI/volume-control.cpp
@@ -70,38 +70,36 @@ void VolControl::VolumeMuted(bool muted)
 void VolControl::SetMuted(bool checked)
 {
 	obs_source_set_muted(source, checked);
+
+#if defined(_WIN32) || defined(__APPLE__) || HAVE_PULSEAUDIO
+	if (headphone->isChecked())
+		SetMonitorType(checked, true);
+#endif
 }
 
 void VolControl::SetMonitor(bool checked)
 {
-	headphonesChecked = checked;
-
-	SetMonitorType();
+	SetMonitorType(mute->isChecked(), checked);
 }
 
-void VolControl::SetMonitorOnly(bool checked)
-{
-	monitorOnlyChecked = checked;
-
-	SetMonitorType();
-}
-
-void VolControl::SetMonitorType()
+void VolControl::SetMonitorType(bool mute_checked, bool monitor_checked)
 {
 	const char *type = nullptr;
 
-	if (!headphonesChecked) {
+	if (!monitor_checked) {
 		obs_source_set_monitoring_type(source,
 				OBS_MONITORING_TYPE_NONE);
 		type = "none";
-	} else if (headphonesChecked && monitorOnlyChecked) {
-		obs_source_set_monitoring_type(source,
-				OBS_MONITORING_TYPE_MONITOR_ONLY);
-		type = "monitor only";
-	} else if (headphonesChecked && !monitorOnlyChecked) {
-		obs_source_set_monitoring_type(source,
-				OBS_MONITORING_TYPE_MONITOR_AND_OUTPUT);
-		type = "monitor and output";
+	} else {  // monitoring on
+		if (mute_checked) {
+			obs_source_set_monitoring_type(source,
+					OBS_MONITORING_TYPE_MONITOR_ONLY);
+			type = "monitor only";
+		} else {
+			obs_source_set_monitoring_type(source,
+					OBS_MONITORING_TYPE_MONITOR_AND_OUTPUT);
+			type = "monitor and output";
+		}
 	}
 
 	blog(LOG_INFO, "User changed audio monitoring for source '%s' to: %s",
@@ -167,7 +165,9 @@ VolControl::VolControl(OBSSource source_, bool showConfig)
 	volLabel  = new QLabel();
 	volMeter  = new VolumeMeter(0, obs_volmeter);
 	mute      = new MuteCheckBox();
+#if defined(_WIN32) || defined(__APPLE__) || HAVE_PULSEAUDIO
 	headphone = new HeadphoneCheckBox();
+#endif
 	slider    = new QSlider(Qt::Horizontal);
 
 	QFont font = nameLabel->font();
@@ -195,26 +195,26 @@ VolControl::VolControl(OBSSource source_, bool showConfig)
 	mute->setAccessibleName(
 			QTStr("VolControl.Mute").arg(sourceName));
 
+#if defined(_WIN32) || defined(__APPLE__) || HAVE_PULSEAUDIO
 	headphone->setAccessibleName(
 			QTStr("VolControl.Headphones").arg(sourceName));
 
-	int mt = obs_source_get_monitoring_type(source);
-
-	switch (mt) {
-	case OBS_MONITORING_TYPE_NONE:
-		headphone->setChecked(false);
-		break;
-	case OBS_MONITORING_TYPE_MONITOR_ONLY:
-		headphone->setChecked(true);
-		break;
-	case OBS_MONITORING_TYPE_MONITOR_AND_OUTPUT:
-		headphone->setChecked(true);
-		break;
+	switch (obs_source_get_monitoring_type(source)) {
+		case OBS_MONITORING_TYPE_NONE:
+			headphone->setChecked(false);
+			break;
+		case OBS_MONITORING_TYPE_MONITOR_ONLY:
+		case OBS_MONITORING_TYPE_MONITOR_AND_OUTPUT:
+			headphone->setChecked(true);
+			break;
 	}
+#endif
 
 	volLayout->addWidget(slider);
 	volLayout->addWidget(mute);
+#if defined(_WIN32) || defined(__APPLE__) || HAVE_PULSEAUDIO
 	volLayout->addWidget(headphone);
+#endif
 	volLayout->setSpacing(5);
 
 	botLayout->setContentsMargins(0, 0, 0, 0);
@@ -257,8 +257,11 @@ VolControl::VolControl(OBSSource source_, bool showConfig)
 			this, SLOT(SliderChanged(int)));
 	QWidget::connect(mute, SIGNAL(clicked(bool)),
 			this, SLOT(SetMuted(bool)));
+
+#if defined(_WIN32) || defined(__APPLE__) || HAVE_PULSEAUDIO
 	QWidget::connect(headphone, SIGNAL(clicked(bool)),
 			this, SLOT(SetMonitor(bool)));
+#endif
 
 	obs_fader_attach_source(obs_fader, source);
 	obs_volmeter_attach_source(obs_volmeter, source);

--- a/UI/volume-control.hpp
+++ b/UI/volume-control.hpp
@@ -262,12 +262,8 @@ public:
 
 	void SetMeterDecayRate(qreal q);
 
-	void SetMonitorType();
-
-	bool headphonesChecked;
-	bool monitorOnlyChecked;
+	void SetMonitorType(bool mute_checked, bool monitor_checked);
 
 public slots:
 	void SetMonitor(bool checked);
-	void SetMonitorOnly(bool checked);
 };

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -2321,14 +2321,6 @@ void OBSBasic::GetAudioSourceProperties()
 	CreatePropertiesWindow(source);
 }
 
-void OBSBasic::MonitorOnlyToggled(bool checked)
-{
-	QAction *action = reinterpret_cast<QAction*>(sender());
-	VolControl *vol = action->property("volControl").value<VolControl*>();
-
-	vol->SetMonitorOnly(checked);
-}
-
 void OBSBasic::HideAudioControl()
 {
 	QAction *action = reinterpret_cast<QAction*>(sender());
@@ -2425,24 +2417,6 @@ void OBSBasic::VolControlContextMenu()
 
 	/* ------------------- */
 
-	QAction monitorOnlyAction(
-			QTStr("Basic.AdvAudio.Monitoring.MonitorOnly"), this);
-	monitorOnlyAction.setCheckable(true);
-
-	int mt = obs_source_get_monitoring_type(vol->GetSource());
-
-	switch (mt) {
-	case OBS_MONITORING_TYPE_NONE:
-		monitorOnlyAction.setChecked(false);
-		break;
-	case OBS_MONITORING_TYPE_MONITOR_ONLY:
-		monitorOnlyAction.setChecked(true);
-		break;
-	case OBS_MONITORING_TYPE_MONITOR_AND_OUTPUT:
-		monitorOnlyAction.setChecked(false);
-		break;
-	}
-
 	QAction hideAction(QTStr("Hide"), this);
 	QAction unhideAllAction(QTStr("UnhideAll"), this);
 	QAction mixerRenameAction(QTStr("Rename"), this);
@@ -2453,9 +2427,6 @@ void OBSBasic::VolControlContextMenu()
 
 	/* ------------------- */
 
-	connect(&monitorOnlyAction, &QAction::triggered,
-			this, &OBSBasic::MonitorOnlyToggled,
-			Qt::DirectConnection);
 	connect(&hideAction, &QAction::triggered,
 			this, &OBSBasic::HideAudioControl,
 			Qt::DirectConnection);
@@ -2478,8 +2449,6 @@ void OBSBasic::VolControlContextMenu()
 
 	/* ------------------- */
 
-	monitorOnlyAction.setProperty("volControl",
-			QVariant::fromValue<VolControl*>(vol));
 	hideAction.setProperty("volControl",
 			QVariant::fromValue<VolControl*>(vol));
 	mixerRenameAction.setProperty("volControl",
@@ -2493,7 +2462,6 @@ void OBSBasic::VolControlContextMenu()
 	/* ------------------- */
 
 	QMenu popup(this);
-	popup.addAction(&monitorOnlyAction);
 	popup.addSeparator();
 	popup.addAction(&unhideAllAction);
 	popup.addAction(&hideAction);

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -406,8 +406,6 @@ public slots:
 	void SetCurrentScene(OBSSource scene, bool force = false,
 			bool direct = false);
 
-	void MonitorOnlyToggled(bool checked);
-
 private slots:
 	void AddSceneItem(OBSSceneItem item);
 	void RemoveSceneItem(OBSSceneItem item);

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -1307,7 +1307,7 @@ static void source_output_audio_data(obs_source_t *source,
 
 	pthread_mutex_unlock(&source->audio_buf_mutex);
 
-	source_signal_audio_data(source, data, source_muted(source, os_time));
+	source_signal_audio_data(source, data, source_muted(source, os_time) && source->monitoring_type != OBS_MONITORING_TYPE_MONITOR_ONLY);
 }
 
 enum convert_type {


### PR DESCRIPTION
Done: 
- [x] Monitor-only state is activated by muting the stream and enabling the monitor
- [x] Removed the dangerous context menu item
- [x] `#if WIN || MAC || PULSEAUDIO`
- [x] [Tooltip](https://github.com/obsproject/obs-studio/pull/1253#issuecomment-385100417)